### PR TITLE
Update nodejs to 14, fix psql rpm URL

### DIFF
--- a/roles/env/node/tasks/main.yml
+++ b/roles/env/node/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install RPM repo config of node.js
-  shell: "curl -fsSL 'https://rpm.nodesource.com/setup_10.x' | bash -"
+  shell: "curl -fsSL 'https://rpm.nodesource.com/setup_14.x' | bash -"
   args:
     creates: /etc/yum.repos.d/nodesource-el7.repo
 

--- a/roles/env/pgsql/tasks/main.yml
+++ b/roles/env/pgsql/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Install RPM repo config of PostgreSQL
   yum:
-    name: 'https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-7-x86_64/pgdg-centos11-11-2.noarch.rpm'
+    name: 'https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm'
     state: installed
 
 - name: Install PostgreSQL Client/Server


### PR DESCRIPTION
## Description
Fixed 2 problems, appeared while initializing my development environment. With this PR, I could complete creating my dev environment.

## Description (日本語)
指示通り環境構築をしたところ2つの問題を発見したので、それぞれ修正して環境構築が最後まで行えるようにしました。

- nodeのバージョンが古く、Typescriptの構文エラーが発生していたため、バージョンを上げました
  - 具体的に発生していたエラーはこれです https://github.com/TypeStrong/ts-node/issues/1218

> /var/www/statink/statink/node_modules/postcss-load-config/node_modules/yaml/dist/compose/composer.js:33
>                 if (prelude[i + 1]?.[0] !== '#')
>                                    ^
>
> SyntaxError: Unexpected token '.'
>     at wrapSafe (internal/modules/cjs/loader.js:915:16)
>     at Module._compile (internal/modules/cjs/loader.js:963:27)
>     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
>     at Module.load (internal/modules/cjs/loader.js:863:32)
>     at Function.Module._load (internal/modules/cjs/loader.js:708:14)
> (以下略)

- PostgreSQL の rpm のダウンロード URL が404になっていたため、[Wiki](https://github.com/fetus-hina/stat.ink/wiki/How-to-setup-a-development-environment#setup-additional-packages%E8%BF%BD%E5%8A%A0%E3%81%AE%E3%83%91%E3%83%83%E3%82%B1%E3%83%BC%E3%82%B8%E3%81%AE%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97)にあった URL に差し替えて PostgreSQL がインストールできるようにしました。

## Need to review
- node は最低動作するバージョンに上げましたが、Latest LTS(=18)にあげても良いかもしれません
- PostgreSQL はとりあえず latest バージョンにしてしまいましたが、バージョンを固定しても良いかもしれません。