### PR TITLE
Allow kernel upgrades to let VM build on newer versions of vagrant-vbguest

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,8 @@ Vagrant.configure("2") do |config|
     vb.memory = "1024"
   end
 
+  config.vbguest.installer_options = { allow_kernel_upgrade: true }
+
   config.vm.synced_folder ".", "/vagrant",  create: true, owner: "vagrant", group: "vagrant"
   config.vm.network "private_network", type: "dhcp"
 


### PR DESCRIPTION
Closes #3 with the suggested fix in the issue. 